### PR TITLE
Support key-based unit send amounts

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -17,7 +17,22 @@ public class PlayerController : MonoBehaviour
     public UIManager uiManager;
     private List<Star> selectedStars = new List<Star>();
     private Star hoveredStar;
-    private int unitsToSend = 10;
+    // Valeurs par défaut pour l'envoi rapide avec les touches A et E
+    [SerializeField] private int unitsForKeyA = 10;
+    [SerializeField] private int unitsForKeyE = 100;
+
+    public int UnitsForKeyA => unitsForKeyA;
+    public int UnitsForKeyE => unitsForKeyE;
+
+    public void SetUnitsForKeyA(int value)
+    {
+        unitsForKeyA = Mathf.Max(0, value);
+    }
+
+    public void SetUnitsForKeyE(int value)
+    {
+        unitsForKeyE = Mathf.Max(0, value);
+    }
     public float unitSpeed = 2.0f;
     private GalaxyManager galaxyManager;
     private LineRenderer hoverLine;
@@ -78,32 +93,49 @@ public class PlayerController : MonoBehaviour
 
     void HandleUnitSend()
     {
-        if (Input.GetKeyDown(KeyCode.O) && hoveredStar != null && selectedStars.Count > 0)
+        if (hoveredStar == null || selectedStars.Count == 0)
         {
-            foreach (Star selectedStar in selectedStars)
-            {
-                if (selectedStar.Owner == player)
-                {
-                    int unitsToSendFromStar = Mathf.Min(unitsToSend, selectedStar.units);
+            return;
+        }
 
-                    if (unitsToSendFromStar > 0)
-                    {
-                        PathFinding pathFinding = FindObjectOfType<PathFinding>();
-                        List<Star> path = pathFinding.FindPath(selectedStar, hoveredStar);
-                        if (path.Count > 0)
-                        {
-                            StartCoroutine(FindObjectOfType<UnitManager>().MoveUnits(selectedStar, path, unitsToSendFromStar));
-                        }
-                        else
-                        {
-                            Debug.LogWarning("No path found!");
-                        }
-                    }
-                    else
-                    {
-                        Debug.LogWarning("No units to send!");
-                    }
+        if (Input.GetKeyDown(KeyCode.A))
+        {
+            SendUnitsToHovered(unitsForKeyA);
+        }
+
+        if (Input.GetKeyDown(KeyCode.E))
+        {
+            SendUnitsToHovered(unitsForKeyE);
+        }
+    }
+
+    void SendUnitsToHovered(int amount)
+    {
+        foreach (Star selectedStar in selectedStars)
+        {
+            if (selectedStar.Owner != player)
+            {
+                continue;
+            }
+
+            int unitsToSendFromStar = Mathf.Min(amount, selectedStar.units);
+
+            if (unitsToSendFromStar > 0)
+            {
+                PathFinding pathFinding = FindObjectOfType<PathFinding>();
+                List<Star> path = pathFinding.FindPath(selectedStar, hoveredStar);
+                if (path.Count > 0)
+                {
+                    StartCoroutine(FindObjectOfType<UnitManager>().MoveUnits(selectedStar, path, unitsToSendFromStar));
                 }
+                else
+                {
+                    Debug.LogWarning("No path found!");
+                }
+            }
+            else
+            {
+                Debug.LogWarning("No units to send!");
             }
         }
     }

--- a/Assets/Scripts/UI/UnitSendSettingsUI.cs
+++ b/Assets/Scripts/UI/UnitSendSettingsUI.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using TMPro;
+
+public class UnitSendSettingsUI : MonoBehaviour
+{
+    public PlayerController playerController;
+    public TMP_InputField keyAInput;
+    public TMP_InputField keyEInput;
+
+    void Start()
+    {
+        if (playerController == null)
+        {
+            playerController = FindObjectOfType<PlayerController>();
+        }
+
+        if (keyAInput != null)
+        {
+            keyAInput.text = playerController.UnitsForKeyA.ToString();
+            keyAInput.onEndEdit.AddListener(OnKeyAChanged);
+        }
+
+        if (keyEInput != null)
+        {
+            keyEInput.text = playerController.UnitsForKeyE.ToString();
+            keyEInput.onEndEdit.AddListener(OnKeyEChanged);
+        }
+    }
+
+    void OnKeyAChanged(string value)
+    {
+        if (int.TryParse(value, out int amount))
+        {
+            playerController.SetUnitsForKeyA(amount);
+        }
+        else if (keyAInput != null)
+        {
+            keyAInput.text = playerController.UnitsForKeyA.ToString();
+        }
+    }
+
+    void OnKeyEChanged(string value)
+    {
+        if (int.TryParse(value, out int amount))
+        {
+            playerController.SetUnitsForKeyE(amount);
+        }
+        else if (keyEInput != null)
+        {
+            keyEInput.text = playerController.UnitsForKeyE.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/UI/UnitSendSettingsUI.cs.meta
+++ b/Assets/Scripts/UI/UnitSendSettingsUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4421e65218e44e289f198e12db20666e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- allow configuring default unit amounts for keys `A` and `E`
- remove old `O` key logic
- add `UnitSendSettingsUI` to update values from TMP input fields
- expose update methods on `PlayerController`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517e78e2e4832fb1a80357bfb6c9d7